### PR TITLE
chore: bump nvidia/distroless/go from v3.1.9 to v3.1.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN task build
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM nvcr.io/nvidia/distroless/go:v3.1.9
+FROM nvcr.io/nvidia/distroless/go:v3.1.10
 WORKDIR /
 COPY --from=builder /workspace/build/nic-feature-discovery .
 COPY . /src


### PR DESCRIPTION
Bumps nvidia/distroless/go from v3.1.9 to v3.1.10.

---
updated-dependencies:
- dependency-name: nvidia/distroless/go dependency-version: v3.1.10 dependency-type: direct:production ...