### PR TITLE
ci: update netop CI branch trigger for main

### DIFF
--- a/.github/workflows/netop-ci.yml
+++ b/.github/workflows/netop-ci.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - network-operator-*
     branches:
-      - network-operator-*
+      - main
 
 jobs:
   call-reusable-ci-fork-workflow:


### PR DESCRIPTION
## Summary
- replace the `network-operator-*` branch trigger in the reusable fork-ci workflow with `main`, the repo default branch
- keep `network-operator-*` tag triggers for release builds

## Verification
- YAML parse check for `.github/workflows/netop-ci.*`
- `git diff --check`